### PR TITLE
Wire OpenAI JSON flow and add orange ticket

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,28 @@ guardrails:
 
 ## Usage
 
-Run via `npm start` or directly with Node. If `--ticket` is omitted, the sample ticket is used.
+A ready-to-run smoke ticket lives at `tickets/color-orange.md`; omit `--ticket` to fall back to `tickets/sample.md`.
+
+## Run
 
 ```bash
-npm start -- --ticket tickets/sample.md
-# or
+npm start -- --ticket tickets/color-orange.md
+```
+
+Set the following environment variables before running:
+
+- `OPENAI_API_KEY`
+- `GITHUB_TOKEN`
+- `GITHUB_OWNER`
+- `GITHUB_REPO` (defaults to `bloom`)
+- `GITHUB_BASE_BRANCH` (defaults to `main`)
+- `OPENAI_MODEL` (optional, defaults to `gpt-4.1-mini`)
+
+The target repository (for example, `bloom`) must have Vercel PR previews configured and native auto-merge enabled with at least one required check so the engine can arm auto-merge.
+
+Run via `npm start` or directly with Node if you need a custom ticket path.
+
+```bash
 node orchestrator.js --ticket path/to/ticket.md
 ```
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "type": "commonjs",
   "dependencies": {
     "@octokit/graphql": "^7.1.0",
     "@octokit/rest": "^21.0.2",

--- a/tickets/color-orange.md
+++ b/tickets/color-orange.md
@@ -1,0 +1,10 @@
+# shipyard:ticket
+title: "Change brand color from pink to orange (single file)"
+why: "Visual smoke to confirm end-to-end loop"
+scope:
+  - src/app/layout.tsx
+dod:
+  - "Replace Tailwind pink/fuchsia classes with orange equivalents (e.g., text-orange-500)"
+guardrails:
+  - "Touch only the file listed in scope"
+  - "Keep edits minimal; do not change copy, layout, or other colors"


### PR DESCRIPTION
## Summary
- switch the orchestrator to the chat completions JSON mode helper and keep the sequential logging
- ensure the package runs in CommonJS mode and document the new sample ticket flow
- add the color-orange smoke ticket that exercises src/app/layout.tsx edits

## Testing
- not run (requires external services)


------
https://chatgpt.com/codex/tasks/task_e_68d2f41182d48333957be9444794e230