### PR TITLE
Fix auto-merge GraphQL variable name

### DIFF
--- a/orchestrator.js
+++ b/orchestrator.js
@@ -313,18 +313,19 @@ async function openPrAndEnableAutoMerge(octokit, ticket, branchName, baseBranch,
 
   try {
     await gql(
-      `mutation EnableAutoMerge($pullRequestId: ID!, $method: PullRequestMergeMethod!) {
-        enablePullRequestAutoMerge(input: { pullRequestId: $pullRequestId, mergeMethod: $method }) {
-          clientMutationId
-        }
+      `mutation EnableAutoMerge(
+        $pullRequestId: ID!
+        $mergeMethod: PullRequestMergeMethod!
+      ) {
+        enablePullRequestAutoMerge(input: {
+          pullRequestId: $pullRequestId,
+          mergeMethod: $mergeMethod
+        }) { clientMutationId }
       }`,
-      {
-        pullRequestId: pr.data.node_id,
-        method: "SQUASH",
-      }
+      { pullRequestId: pr.data.node_id, mergeMethod: "SQUASH" }
     );
-  } catch (error) {
-    console.warn(`Auto-merge not enabled: ${error.message}`);
+  } catch (e) {
+    console.warn(`Auto-merge not enabled: ${e.message}`);
   }
 
   console.log(`PR ready: ${pr.data.html_url}`);


### PR DESCRIPTION
## Summary
- update the auto-merge GraphQL mutation to use the mergeMethod variable name required by GitHub
- continue logging a warning without aborting if enabling auto-merge fails

## Testing
- not run (requires GitHub credentials for GitHub API)

------
https://chatgpt.com/codex/tasks/task_e_68d2f85a710083339dd556ba8d7886e2