### PR TITLE
Lock OpenAI model to gpt-5-mini

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 OPENAI_API_KEY=
-OPENAI_MODEL=gpt-4.1-mini
+# Default model (override with OPENAI_MODEL env var if needed)
+OPENAI_MODEL=gpt-5-mini
 GITHUB_TOKEN=
 GITHUB_OWNER=
 GITHUB_REPO=bloom

--- a/orchestrator.js
+++ b/orchestrator.js
@@ -214,9 +214,8 @@ async function callOpenAI(ticket, scopeFiles) {
   const user = buildOpenAIInput(ticket, scopeFiles);
 
   const resp = await openai.chat.completions.create({
-    model: process.env.OPENAI_MODEL || "gpt-4.1-mini",
+    model: process.env.OPENAI_MODEL || "gpt-5-mini",
     response_format: { type: "json_object" },
-    temperature: 0,
     messages: [
       { role: "system", content: system },
       { role: "user", content: user },


### PR DESCRIPTION
## Summary
- default the orchestrator OpenAI client to the gpt-5-mini model without specifying temperature
- document the OPENAI_MODEL default in the environment example file

## Testing
- not run (requires external OPENAI_API_KEY)


------
https://chatgpt.com/codex/tasks/task_e_68d2f9f90f988333ac4addcafe46b2a1