### PR TITLE
Fix(engine): Add Base64 encoding for file contents before commit

### DIFF
--- a/orchestrator.js
+++ b/orchestrator.js
@@ -265,7 +265,7 @@ async function commitFiles(octokit, owner, repo, branchName, files, scopeFiles) 
       repo,
       path: file.path,
       message,
-      content: file.base64,
+      content: Buffer.from(file.contents, "utf8").toString("base64"),
       branch: branchName,
       sha: existingSha,
       committer: {


### PR DESCRIPTION
## Summary
- ensure commit payloads sent to GitHub are base64 encoded from utf8 text

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d2fb9504e0833385b73ecb97b65b66