### PR TITLE
Add LLM provider switch, SafeReplace, and sanity rails

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,10 @@ GITHUB_OWNER=
 GITHUB_REPO=bloom
 GITHUB_BASE_BRANCH=main
 USE_SCRIPTED_MERGE=false
+LLM_PROVIDER=openai
+# OpenAI remains supported via existing OPENAI_* vars
+ANTHROPIC_API_KEY=
+ANTHROPIC_MODEL=claude-3-5-sonnet-latest
+ANTHROPIC_VERSION=2023-06-01
+ANTHROPIC_BASE_URL=https://api.anthropic.com
+VERIFY_STRICT=true

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Shipyard Engine v1
 
-Shipyard Engine turns structured human tickets into GitHub pull requests that are ready to auto-merge. Provide a ticket file, the engine gathers repository context, asks OpenAI for minimal edits, commits them on a feature branch, opens a PR, and attempts to arm auto-merge.
+Shipyard Engine turns structured human tickets into GitHub pull requests that are ready to auto-merge. Provide a ticket file, the engine gathers repository context, asks the configured LLM provider (OpenAI by default) for minimal edits or applies literal SafeReplace edits, commits them on a feature branch, opens a PR, and attempts to arm auto-merge.
 
 ## Prerequisites
 
@@ -8,7 +8,7 @@ Shipyard Engine turns structured human tickets into GitHub pull requests that ar
 - npm to install dependencies
 - Repository with "Allow auto-merge" enabled or the optional scripted merge fallback
 - GitHub token with `contents:write`, `pull_requests:write`, and `metadata:read` access (a classic PAT with `repo` scope works)
-- OpenAI API key with access to the selected `OPENAI_MODEL`
+- Credentials for your selected LLM provider (OpenAI by default)
 - Branch protection that requires at least one check (the bundled smoke workflow can satisfy this)
 - Vercel (or another CI) PR previews recommended; if unavailable, the smoke workflow provides a minimal required check
 
@@ -23,18 +23,59 @@ npm install
 Copy `.env.example` to `.env` and fill in the values:
 
 ```dotenv
+LLM_PROVIDER=openai
 OPENAI_API_KEY=sk-...
 OPENAI_MODEL=gpt-4.1-mini
+ANTHROPIC_API_KEY=
+ANTHROPIC_MODEL=claude-3-5-sonnet-latest
+ANTHROPIC_VERSION=2023-06-01
+ANTHROPIC_BASE_URL=https://api.anthropic.com
 GITHUB_TOKEN=ghp_...
 GITHUB_OWNER=your-github-handle
 GITHUB_REPO=bloom
 GITHUB_BASE_BRANCH=main
+VERIFY_STRICT=true
 ```
 
 - `OPENAI_MODEL` defaults to `gpt-4.1-mini` if omitted.
 - `GITHUB_REPO` defaults to `bloom`; override when pointing at a different repository.
 - `GITHUB_BASE_BRANCH` defaults to `main`.
 - `GITHUB_OWNER` and `GITHUB_TOKEN` are always required.
+- `LLM_PROVIDER` defaults to `openai`; set to `anthropic` to use Claude instead.
+- When `LLM_PROVIDER=anthropic`, provide `ANTHROPIC_API_KEY` and optionally override `ANTHROPIC_MODEL`, `ANTHROPIC_VERSION`, or `ANTHROPIC_BASE_URL`.
+- `VERIFY_STRICT` controls the Sanity Rails check (see below) and should remain `true` unless you fully trust downstream safeguards.
+
+## LLM provider switch
+
+Shipyard Engine now routes all model calls through a provider-agnostic adapter. By default it continues to use OpenAI, but you can flip to Anthropic (Claude) by exporting:
+
+```dotenv
+LLM_PROVIDER=anthropic
+ANTHROPIC_API_KEY=sk-ant-...
+ANTHROPIC_MODEL=claude-3-5-sonnet-latest
+```
+
+The OpenAI environment variables remain supported, so you can swap providers by changing `LLM_PROVIDER` and supplying the corresponding credentials. `ANTHROPIC_VERSION` and `ANTHROPIC_BASE_URL` default to Anthropic's hosted API but can be overridden for self-hosted gateways.
+
+## SafeReplace mode
+
+For deterministic, low-risk edits you can bypass the LLM entirely with a `safe_replace` block inside the ticket YAML. Provide literal `find`/`replace` pairs and the engine will apply them sequentially to the base branch content:
+
+```yaml
+safe_replace:
+  - path: src/app/layout.tsx
+    replacements:
+      - find: "text-orange-500"
+        replace: "text-purple-500"
+      - find: "bg-orange-50"
+        replace: "bg-purple-50"
+```
+
+If any `find` token is missing the engine logs the omission and leaves the file untouched. When at least one replacement succeeds, the updated files continue through the normal validation, commit, and PR flow.
+
+## Sanity Rails
+
+Before committing, the engine runs a strict sanity check on every modified file (unless `VERIFY_STRICT=false`). It rejects updates that are empty, exceed 200 KB, contain non-printable bytes, or strip required exports from `src/app/layout.tsx` or `NowPlaying.tsx`. Failures abort the run with a `SanityRails` error message—only disable the guardrail if you have redundant protections downstream.
 
 ## Ticket format
 
@@ -67,7 +108,9 @@ npm start -- --ticket tickets/color-orange.md
 
 Set the following environment variables before running:
 
-- `OPENAI_API_KEY`
+- `LLM_PROVIDER` (defaults to `openai`)
+- `OPENAI_API_KEY` (required when `LLM_PROVIDER=openai`)
+- `ANTHROPIC_API_KEY` (required when `LLM_PROVIDER=anthropic`)
 - `GITHUB_TOKEN`
 - `GITHUB_OWNER`
 - `GITHUB_REPO` (defaults to `bloom`)
@@ -86,8 +129,8 @@ node orchestrator.js --ticket path/to/ticket.md
 
 1. Reads and validates the ticket (`1/7 read ticket…`).
 2. Fetches the current contents of each scope file from the base branch (`2/7 fetch scope files…`).
-3. Calls OpenAI with the ticket and file context, enforcing a strict JSON contract (`3/7 call OpenAI…`).
-4. Validates the JSON payload, rejecting paths outside scope, invalid base64, or >5 files (`4/7 validate JSON…`).
+3. Either executes literal SafeReplace edits or calls the configured LLM provider with the ticket and file context (`3/7 safe replace…` or `3/7 call LLM…`).
+4. Runs Sanity Rails (unless disabled) to catch suspicious output before committing (`4/7 run sanity rails…`).
 5. Creates a feature branch named `intent-<slug(title)>-<shortid>` (`5/7 create branch…`).
 6. Commits the AI-provided edits with messages prefixed by `shipyard:` (`6/7 commit…`).
 7. Opens a PR, posts the ticket YAML in the body, and attempts to enable auto-merge (`7/7 open PR + arm auto-merge…`).
@@ -106,7 +149,7 @@ The repository includes `.github/workflows/smoke.yml`, a minimal check that alwa
 | `Ticket scope must be a non-empty array` | Ticket missing `scope` entries | Update ticket file |
 | `Scope path not found in base branch` | File listed in scope missing from base branch | Update scope or create file manually |
 | `Scope path is a directory, expected file` | Directory scopes not yet supported | Point to specific files |
-| `JSON invalid` / `Model attempted to modify path outside scope` | OpenAI output rejected by safety checks | Re-run, refine scope, or adjust guardrails |
+| `JSON invalid` / `Model attempted to modify path outside scope` | LLM output rejected by safety checks | Re-run, refine scope, or adjust guardrails |
 | `Branch already exists` | Generated branch name already present | Delete the branch or edit the ticket title |
 | `Auto-merge not enabled: ...` | Repository disallows auto-merge or token lacks scope | Enable auto-merge in repo settings or supply a token with `pull_request:write` |
 | GitHub `403`/`404` errors | Token lacks permissions or repository/branch incorrect | Confirm env vars and token scopes |

--- a/package.json
+++ b/package.json
@@ -17,7 +17,12 @@
     "dotenv": "^16.4.5",
     "js-yaml": "^4.1.0",
     "nanoid": "^5.0.7",
+    "node-fetch": "^2.7.0",
     "openai": "^4.52.0",
     "yargs": "^17.7.2"
+  },
+  "devDependencies": {
+    "eslint": "^8.57.0",
+    "typescript": "^5.4.5"
   }
 }


### PR DESCRIPTION
## Summary
- introduce provider-agnostic `callLLM` with Anthropic adapter alongside existing OpenAI integration
- add SafeReplace deterministic replacement path and pre-commit Sanity Rails validations
- document new environment variables, provider switch workflow, and guardrails in README

## Testing
- `node orchestrator.js --help`


------
https://chatgpt.com/codex/tasks/task_e_68d40e25994483338708629c870c611b