### PR TITLE
Cap Anthropic max tokens with configurable clamp

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,4 +12,6 @@ ANTHROPIC_API_KEY=
 ANTHROPIC_MODEL=claude-3-5-sonnet-latest
 ANTHROPIC_VERSION=2023-06-01
 ANTHROPIC_BASE_URL=https://api.anthropic.com
+# Anthropic output cap (tokens) – safe default
+ANTHROPIC_MAX_TOKENS=4000
 VERIFY_STRICT=true

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ ANTHROPIC_API_KEY=
 ANTHROPIC_MODEL=claude-3-5-sonnet-latest
 ANTHROPIC_VERSION=2023-06-01
 ANTHROPIC_BASE_URL=https://api.anthropic.com
+ANTHROPIC_MAX_TOKENS=4000
 GITHUB_TOKEN=ghp_...
 GITHUB_OWNER=your-github-handle
 GITHUB_REPO=bloom
@@ -43,6 +44,7 @@ VERIFY_STRICT=true
 - `GITHUB_OWNER` and `GITHUB_TOKEN` are always required.
 - `LLM_PROVIDER` defaults to `openai`; set to `anthropic` to use Claude instead.
 - When `LLM_PROVIDER=anthropic`, provide `ANTHROPIC_API_KEY` and optionally override `ANTHROPIC_MODEL`, `ANTHROPIC_VERSION`, or `ANTHROPIC_BASE_URL`.
+- `ANTHROPIC_MAX_TOKENS` defaults to `4000`, is clamped between `256` and Anthropic's `32000` hard limit, and governs Claude's response length; 2–8k tokens is ample for typical `{files:[...]}` diffs.
 - `VERIFY_STRICT` controls the Sanity Rails check (see below) and should remain `true` unless you fully trust downstream safeguards.
 
 ## LLM provider switch

--- a/orchestrator.js
+++ b/orchestrator.js
@@ -255,6 +255,8 @@ async function callAnthropic(ticket, scopeFiles) {
   const baseUrl = (process.env.ANTHROPIC_BASE_URL || "https://api.anthropic.com").replace(/\/$/, "");
   const version = process.env.ANTHROPIC_VERSION || "2023-06-01";
   const model = process.env.ANTHROPIC_MODEL || "claude-3-5-sonnet-latest";
+  const maxTokens = Number(process.env.ANTHROPIC_MAX_TOKENS || 4000);
+  const clampedTokens = Math.max(256, Math.min(maxTokens, 32000));
 
   const system = buildSystemPrompt();
   const user = buildOpenAIInput(ticket, scopeFiles);
@@ -269,7 +271,7 @@ async function callAnthropic(ticket, scopeFiles) {
     body: JSON.stringify({
       model,
       temperature: 0,
-      max_tokens: 200000,
+      max_tokens: clampedTokens,
       system,
       messages: [{ role: "user", content: user }],
     }),


### PR DESCRIPTION
## Summary
- clamp Anthropic max_tokens via configurable ANTHROPIC_MAX_TOKENS env var
- document the new environment variable and recommended values

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d418f763348333950d56671af7e4e2